### PR TITLE
Moon Series set updates

### DIFF
--- a/script_res/setdex_tt2019.js
+++ b/script_res/setdex_tt2019.js
@@ -122,7 +122,7 @@ var SETDEX_TT2019 = {
             },
             "nature": "Timid",
             "ability": "",
-            "item": "Sitrus Berry",
+            "item": "",
             "moves": [
                 "Hurricane",
                 "Air Slash",
@@ -614,12 +614,12 @@ var SETDEX_TT2019 = {
         "Default Set": {
             "level": 50,
             "evs": {
-                "hp": 248,
+                "hp": 252,
                 "at": 0,
-                "df": 4,
+                "df": 0,
                 "sa": 0,
-                "sd": 36,
-                "sp": 220
+                "sd": 4,
+                "sp": 252
             },
             "nature": "Jolly",
             "ability": "",
@@ -1518,15 +1518,15 @@ var SETDEX_TT2019 = {
         "Default Set": {
             "level": 50,
             "evs": {
-                "hp": 252,
+                "hp": 4,
                 "at": 0,
                 "df": 0,
                 "sa": 252,
-                "sd": 4,
-                "sp": 0
+                "sd": 0,
+                "sp": 252
             },
-            "nature": "Mild",
-            "ability": "",
+            "nature": "Timid",
+            "ability": "Dry Skin",
             "item": "",
             "moves": [
                 "Ice Beam",
@@ -3004,6 +3004,26 @@ var SETDEX_TT2019 = {
                 "Overheat"
             ]
         }
+        "Shuca Berry": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Modest",
+            "ability": "Flash Fire",
+            "item": "Shuca Berry",
+            "moves": [
+                "Heat Wave",
+                "Earth Power",
+                "Flash Cannon",
+                "Overheat"
+            ]
+        }        
     },
     "Pangoro": {
         "Default Set": {
@@ -5138,6 +5158,26 @@ var SETDEX_TT2019 = {
         "Default Set": {
             "level": 50,
             "evs": {
+                "hp": 236,
+                "at": 0,
+                "df": 76,
+                "sa": 0,
+                "sd": 180,
+                "sp": 0
+            },
+            "nature": "Sassy",
+            "ability": "",
+            "item": "Figy Berry",
+            "moves": [
+                "Clear Smog",
+                "Grass Knot",
+                "Foul Play",
+                "Sludge Bomb"
+            ]
+        },
+        "Physically Defensive": {
+            "level": 50,
+            "evs": {
                 "hp": 252,
                 "at": 0,
                 "df": 252,
@@ -5147,14 +5187,14 @@ var SETDEX_TT2019 = {
             },
             "nature": "Relaxed",
             "ability": "",
-            "item": "",
+            "item": "Figy Berry",
             "moves": [
                 "Giga Drain",
                 "Sludge Bomb",
                 "Energy Ball",
                 "Clear Smog"
             ]
-        }
+        },        
     },
     "Jolteon": {
         "Default Set": {
@@ -8218,12 +8258,32 @@ var SETDEX_TT2019 = {
             "ability": "Drizzle",
             "item": "",
             "moves": [
-                "Origin Pulse",
                 "Water Spout",
+                "Origin Pulse",
                 "Ice Beam",
                 "Thunder"
             ]
-        }
+        },
+        "Bulky Waterium Z": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Modest",
+            "ability": "Drizzle",
+            "item": "",
+            "moves": [
+                "Water Spout",
+                "Origin Pulse",
+                "Ice Beam",
+                "Thunder"
+            ]
+        }        
     },
 
     "Groudon": {
@@ -8319,23 +8379,43 @@ var SETDEX_TT2019 = {
         "Default Set": {
             "level": 50,
             "evs": {
-                "hp": 0,
-                "at": 0,
+                "hp": 4,
+                "at": 252,
                 "df": 0,
-                "sa": 252,
+                "sa": 0,
                 "sd": 4,
                 "sp": 252
             },
-            "nature": "Timid",
+            "nature": "Jolly",
             "ability": "Dark Aura",
-            "item": "Life Orb",
+            "item": "",
             "moves": [
-                "Oblivion Wing",
-                "Sucker Punch",
                 "Foul Play",
+                "Sucker Punch",
+                "Knock Off",
                 "Snarl"
             ]
-        }
+        },
+        "AV Yveltal": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 0,
+                "df": 4,
+                "sa": 44,
+                "sd": 116,
+                "sp": 164
+            },
+            "nature": "Calm",
+            "ability": "Dark Aura",
+            "item": "Assault Vest",
+            "moves": [
+                "Foul Play",
+                "Sucker Punch",
+                "Oblivion Wing",
+                "Snarl"
+            ]
+        }      
     },
 
     "Dialga": {
@@ -8351,7 +8431,7 @@ var SETDEX_TT2019 = {
             },
             "nature": "Modest",
             "ability": "Pressure",
-            "item": "Adamant Orb",
+            "item": "Figy Berry",
             "moves": [
                 "Draco Meteor",
                 "Flash Cannon",
@@ -8374,12 +8454,12 @@ var SETDEX_TT2019 = {
             },
             "nature": "Modest",
             "ability": "Pressure",
-            "item": "Lustrous Orb",
+            "item": "",
             "moves": [
-                "Draco Meteor",
+                "Spacial Rend",
                 "Hydro Pump",
                 "Earth Power",
-                "Ice Beam"
+                "Draco Meteor"
             ]
         }
     },
@@ -8625,7 +8705,7 @@ var SETDEX_TT2019 = {
                 "sd": 236,
                 "sp": 28
             },
-            "nature": "Adamant",
+            "nature": "Careful",
             "ability": "Intimidate",
             "item": "",
             "moves": [
@@ -9125,10 +9205,10 @@ var SETDEX_TT2019 = {
             "ability": "",
             "item": "",
             "moves": [
-                "Trop Kick",
+                "Power Whip",
                 "High Jump Kick",
-                "",
-                ""
+                "Feint",
+                "Trop Kick"
             ]
         }
     },
@@ -9479,7 +9559,7 @@ var SETDEX_TT2019 = {
     },
 
     "Tapu Koko": {
-        "Special Sweeper": {
+        "Electrium Z": {
             "level": 50,
             "evs": {
                 "hp": 4,
@@ -9491,12 +9571,12 @@ var SETDEX_TT2019 = {
             },
             "nature": "Timid",
             "ability": "Electric Surge",
-            "item": "Life Orb",
+            "item": "",
             "moves": [
                 "Thunderbolt",
                 "Dazzling Gleam",
                 "Volt Switch",
-                "Discharge"
+                "Electroweb"
             ]
         },
         "Specs Koko": {
@@ -9519,7 +9599,7 @@ var SETDEX_TT2019 = {
                 "Discharge"
             ]
         },
-        "Mixed Attacker": {
+        "Mixed Choice Scarf": {
             "level": 50,
             "evs": {
                 "hp": 0,
@@ -9529,14 +9609,14 @@ var SETDEX_TT2019 = {
                 "sd": 0,
                 "sp": 252
             },
-            "nature": "Hasty",
+            "nature": "Naughty",
             "ability": "Electric Surge",
-            "item": "Life Orb",
+            "item": "Choice Scarf",
             "moves": [
                 "Wild Charge",
-                "Thunderbolt",
-                "Dazzling Gleam",
-                "Discharge"
+                "Brave Bird",
+                "Volt Switch",
+                "Hidden Power Fire"
             ]
         },
         "AV Koko": {
@@ -9573,7 +9653,7 @@ var SETDEX_TT2019 = {
                 "sd": 0,
                 "sp": 252
             },
-            "nature": "Modest",
+            "nature": "Timid",
             "ability": "Psychic Surge",
             "item": "",
             "moves": [
@@ -9676,19 +9756,19 @@ var SETDEX_TT2019 = {
           "evs": {
               "hp": 252,
               "at": 0,
-              "df": 4,
-              "sa": 252,
-              "sd": 0,
-              "sp": 0
+              "df": 60,
+              "sa": 4,
+              "sd": 76,
+              "sp": 116
           },
-          "nature": "Modest",
+          "nature": "Calm",
           "ability": "Misty Surge",
-          "item": "Choice Specs",
+          "item": "",
           "moves": [
               "Muddy Water",
               "Scald",
               "Moonblast",
-              "Dazzling Gleam"
+              "Icy Wind"
           ]
       },
         "Specs Fini": {
@@ -9696,18 +9776,18 @@ var SETDEX_TT2019 = {
             "evs": {
                 "hp": 252,
                 "at": 0,
-                "df": 20,
-                "sa": 164,
-                "sd": 44,
-                "sp": 28
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
             },
             "nature": "Modest",
             "ability": "Misty Surge",
             "item": "Choice Specs",
             "moves": [
-                "Hydro Pump",
-                "Moonblast",
                 "Muddy Water",
+                "Moonblast",
+                "Scald",
                 "Dazzling Gleam"
             ]
         },
@@ -9934,6 +10014,27 @@ var SETDEX_TT2019 = {
         "Default Set": {
             "level": 50,
             "evs": {
+                "hp": 68,
+                "at": 4,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 180
+            },
+            "nature": "Jolly",
+            "ability": "",
+            "item": "Assault Vest",
+            "moves": [
+                "Leaf Blade",
+                "Sacred Sword",
+                "Smart Strike",
+                "Knock Off"
+            ]
+        },
+
+        "Grassium Z Kartana": {
+            "level": 50,
+            "evs": {
                 "hp": 4,
                 "at": 252,
                 "df": 0,
@@ -9944,27 +10045,6 @@ var SETDEX_TT2019 = {
             "nature": "Jolly",
             "ability": "",
             "item": "",
-            "moves": [
-                "Leaf Blade",
-                "Sacred Sword",
-                "Smart Strike",
-                "Knock Off"
-            ]
-        },
-
-        "AV Kartana": {
-            "level": 50,
-            "evs": {
-                "hp": 84,
-                "at": 4,
-                "df": 4,
-                "sa": 0,
-                "sd": 164,
-                "sp": 252
-            },
-            "nature": "Jolly",
-            "ability": "",
-            "item": "Assault Vest",
             "moves": [
                 "Leaf Blade",
                 "Sacred Sword",
@@ -10369,12 +10449,32 @@ var SETDEX_TT2019 = {
               "Moongeist Beam",
               "Psyshock",
               "Focus Blast",
-              "Moonblast"
+              "Menacing Moonraze Maelstrom"
           ]
       },
+      "Specs Lunala": {
+          "level": 50,
+          "evs": {
+              "hp": 4,
+              "at": 0,
+              "df": 0,
+              "sa": 252,
+              "sd": 0,
+              "sp": 252
+          },
+          "nature": "Timid",
+          "ability": "Shadow Shield",
+          "item": "Choice Specs",
+          "moves": [
+              "Moongeist Beam",
+              "Psyshock",
+              "Focus Blast",
+              "Moonblast"
+          ]
+      },        
     },
     "Solgaleo" : {
-        "Default Set": {
+      "Default Set": {
             "level": 50,
             "evs": {
                 "hp": 252,
@@ -10394,6 +10494,26 @@ var SETDEX_TT2019 = {
               "Wild Charge"
           ]
       },
+      "Life Orb Solgaleo": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+          "nature": "Jolly",
+          "ability": "Full Metal Body",
+          "item": "Life Orb",
+          "moves": [
+              "Sunsteel Strike",
+              "Superpower",
+              "Zen Headbutt",
+              "Wild Charge"
+          ]
+      },        
     },
     "Dawn Wings Necrozma" : {
       "Default Set": {


### PR DESCRIPTION
-Incineroar - default Nature to Careful (oops this was supposed to be Careful from the start)
-Amoonguss - default spread to be Sp. Def heavy and moved previously default Amoonguss to physically Defensive
-Lunala - add Menacing Moonraze Maelstrom > Moonblast, added Specs set
-Kyogre - added 252 HP / 252 Waterium set
-Palkia - removed Lustrous Orb, changed Spacial Rend -> Ice Beam
-Kartana - changed AV set to be default with more reasonable EVs, changed other Kartana to "Z-move Kartana"
-Tapu Koko - removed Life Orb, Discharge -> Electro Web, changed mixed Attacker set to be Choice Scarf with Brave Bird / Wild Charge / Volt Switch / HP Fire
-Yveltal - changed standard to be physical Jolly 252/252, added AV Yveltal
-Crobat - change to 252 / 252 and removed Black Sludge
-Tapu Lele - changed default to be Timid
-Jynx - changed default to Timid 252/252, added Dry Skin
-Tsareena - added Feint and U-turn, replaced Trop Kick with Power Whip
-Tornadus - removed Sitrus Berry
-Solgaleo - added offensive Jolly LO set
-Tapu Fini - changed default set to be a Calm defensive set and moved 252/252 to the Specs set
-Dialga - changed item to be Figy Berry
-Heatran - changed default set from Modest -> Timid, added Shuca Berry Heatran set