### PR TITLE
Update screens modifier to 0xAAC for Gen 6+

### DIFF
--- a/script_res/damage.js
+++ b/script_res/damage.js
@@ -574,10 +574,10 @@ function getDamageResult(attacker, defender, move, field) {
     description.isBurned = applyBurn;
     var finalMods = [];
     if (field.isReflect && move.category === "Physical" && !isCritical) {
-        finalMods.push(field.format !== "Singles" ? 0xA8F : 0x800);
+        finalMods.push(field.format !== "Singles" ? gen >= 6 ? 0xAAC : 0xA8F : 0x800);
         description.isReflect = true;
     } else if (field.isLightScreen && move.category === "Special" && !isCritical) {
-        finalMods.push(field.format !== "Singles" ? 0xA8F : 0x800);
+        finalMods.push(field.format !== "Singles" ? gen >= 6 ? 0xAAC : 0xA8F : 0x800);
         description.isLightScreen = true;
     }
     if ((defAbility === "Multiscale" || defAbility == "Shadow Shield") && defender.curHP === defender.maxHP) {


### PR DESCRIPTION
We're actually really, really off compared to OZY's research (http://bbs10.aimix-z.com/mtpt.cgi?room=sonota&mode=view2&f=140&no=27-29), but this is a pretty big one that needs changed. I made it gen 6+ because PS damage calc does that, though I don't have a direct source for gen 6 otherwise. I'll make a separate issue for a proper Gen 7 modifier update.