### PR TITLE
Fix burn damage

### DIFF
--- a/script_res/ko_chance.js
+++ b/script_res/ko_chance.js
@@ -120,11 +120,12 @@ function getKOChanceText(damage, move, defender, field, isBadDreams) {
             toxicCounter = defender.toxicCounter;
         }
     } else if (defender.status === 'Burned') {
+        var burnDmgDivider = (gen >= 7) ? 16 : 8;
         if (defender.ability === 'Heatproof') {
-            eot -= Math.floor(defender.maxHP / 16);
+            eot -= Math.floor(defender.maxHP / burnDmgDivider / 2);
             eotText.push('reduced burn damage');
         } else if (defender.ability !== 'Magic Guard') {
-            eot -= Math.floor(defender.maxHP / 8);
+            eot -= Math.floor(defender.maxHP / burnDmgDivider);
             eotText.push('burn damage');
         }
     } else if (defender.status === 'Asleep' && isBadDreams && defender.ability !== 'Magic Guard') {


### PR DESCRIPTION
Burn damage is reduced to 1/16 of HP from generation 7 onward.
Mentioned in issue #79

Signed-off-by: ProfessorSidon <juhofamily@yahoo.com>