### PR TITLE
Update terrain's BP modifiers

### DIFF
--- a/script_res/damage.js
+++ b/script_res/damage.js
@@ -430,13 +430,13 @@ function GET_DAMAGE_SM(attacker, defender, move, field) {
     if (field.isGravity || (attacker.type1 !== "Flying" && attacker.type2 !== "Flying" &&
                 attacker.item !== "Air Balloon" && attacker.ability !== "Levitate")) {
         if (field.terrain === "Electric" && move.type === "Electric") {
-            bpMods.push(0x1800);
+            bpMods.push(0x14cc);
             description.terrain = field.terrain;
         } else if (field.terrain === "Grassy" && move.type == "Grass") {
-            bpMods.push(0x1800);
+            bpMods.push(0x14cc);
             description.terrain = field.terrain;
         }else if (field.terrain === "Psychic" && move.type == "Psychic") {
-            bpMods.push(0x1800);
+            bpMods.push(0x14cc);
             description.terrain = field.terrain;
         }
     }


### PR DESCRIPTION
Terrains have been nerfed to only give a 30% boost (see this : https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-31#post-8307254), this should bring the simulator in line with the change.