### PR TITLE
Fix the calculation of a critical max move

### DIFF
--- a/script_res/damage.js
+++ b/script_res/damage.js
@@ -102,6 +102,7 @@ function GET_DAMAGE_SM(attacker, defender, move, field) {
         moveDescName = MAXMOVES_LOOKUP[move.type] + " (" + move.bp + " BP)";
         move.category = tempMove.category;
         move.isMax = true;
+        move.isCrit = tempMove.isCrit;
         if(attacker.item == "Choice Band" || attacker.item == "Choice Specs" || attacker.item == "Choice Scarf") {
             attacker.item = "";
         }


### PR DESCRIPTION
Assign the isCrit attribute of the original move to the max move.Otherwise, the 'Crit' button would be ineffective when the move is a max move.Hope this helps.@jake-white
Mentioned in https://github.com/jake-white/VGC-Damage-Calculator/issues/101