### PR TITLE
Fix the data of the move 'Overdrive'

### DIFF
--- a/script_res/move_data.js
+++ b/script_res/move_data.js
@@ -3194,6 +3194,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         type: 'Electric',
         category: 'Special',
         isSound: true,
+        isSpread: true
     },
     'Apple Acid': {
         bp: 80,


### PR DESCRIPTION
Overdrive inflicts damage and hits all opposing Pokémon in Double Battles.
Mentioned in https://github.com/jake-white/VGC-Damage-Calculator/issues/106