### PR TITLE
Steely Spirit + missing moves + max + crit bug fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,14 @@
                         <input class="btn-input calc-trigger" type="checkbox" id="powerSpotR" /><label class="btn btn-xxwide" for="powerSpotR">Power Spot</label>
                     </div>
                 </div>
+                <div class="btn-group gen-specific g8">
+                    <div class="left" title="Is this Pokemon boosted by an ally's Steely Spirit?">
+                        <input class="btn-input calc-trigger" type="checkbox" id="steelySpiritL" /><label class="btn btn-xxwide" for="steelySpiritL">Steely Spirit</label>
+                    </div>
+                    <div class="right" title="Is this Pokemon boosted by an ally's Steely Spirit?">
+                        <input class="btn-input calc-trigger" type="checkbox" id="steelySpiritR" /><label class="btn btn-xxwide" for="steelySpiritR">Steely Spirit</label>
+                    </div>
+                </div>
 
                 <div class="btn-group gen-specific g7 g8">
                     <div class="left" title="Has this Pokemon used Geomancy?">

--- a/script_res/ap_calc.js
+++ b/script_res/ap_calc.js
@@ -713,6 +713,7 @@ function Field() {
     var isFriendGuard = [$("#friendGuardL").prop("checked"), $("#friendGuardR").prop("checked")];
     var isBattery = [$("#batteryR").prop("checked"), $("#batteryL").prop("checked")];
     var isPowerSpot = [$("#powerSpotR").prop("checked"), $("#powerSpotL").prop("checked")]; // affects attacks against opposite side
+    var isSteelySpirit = [$("#steelySpiritR").prop("checked"), $("#steelySpiritL").prop("checked")]; // affects attacks against opposite side
 
     this.getWeather = function() {
         return weather;
@@ -724,11 +725,11 @@ function Field() {
         weather = "";
     };
     this.getSide = function(i) {
-        return new Side(format, terrain, weather, isGravity, isSR[i], spikes[i], isReflect[i], isLightScreen[i], isForesight[i], isHelpingHand[i], isFriendGuard[i], isBattery[i], isProtect[i], isPowerSpot[i]);
+        return new Side(format, terrain, weather, isGravity, isSR[i], spikes[i], isReflect[i], isLightScreen[i], isForesight[i], isHelpingHand[i], isFriendGuard[i], isBattery[i], isProtect[i], isPowerSpot[i], isSteelySpirit[i]);
     };
 }
 
-function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLightScreen, isForesight, isHelpingHand, isFriendGuard, isBattery, isProtect, isPowerSpot) {
+function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLightScreen, isForesight, isHelpingHand, isFriendGuard, isBattery, isProtect, isPowerSpot, isSteelySpirit) {
     this.format = format;
     this.terrain = terrain;
     this.weather = weather;
@@ -743,6 +744,7 @@ function Side(format, terrain, weather, isGravity, isSR, spikes, isReflect, isLi
     this.isBattery = isBattery;
     this.isProtect = isProtect;
     this.isPowerSpot = isPowerSpot;
+    this.isSteelySpirit = isSteelySpirit;
 }
 
 var gen, pokedex, setdex, typeChart, moves, abilities, items, STATS, calculateAllMoves, calcHP, calcStat;

--- a/script_res/damage.js
+++ b/script_res/damage.js
@@ -99,8 +99,10 @@ function GET_DAMAGE_SM(attacker, defender, move, field) {
             else if(tempMove.bp >= 45) move.bp = 100;
             else move.bp = 90;
         }
+    
         moveDescName = MAXMOVES_LOOKUP[move.type] + " (" + move.bp + " BP)";
         move.category = tempMove.category;
+        move.isCrit = tempMove.isCrit;
         move.isMax = true;
         if(attacker.item == "Choice Band" || attacker.item == "Choice Specs" || attacker.item == "Choice Scarf") {
             attacker.item = "";
@@ -341,6 +343,11 @@ function GET_DAMAGE_SM(attacker, defender, move, field) {
     if (field.isPowerSpot) {
         bpMods.push(0x14CD)
         description.isPowerSpot = true;
+    }
+
+    if (field.isSteelySpirit && move.type === "Steel") {
+        bpMods.push(0x1800)
+        description.isSteelySpirit = true;
     }
 
     if (attacker.ability === "Sheer Force" && move.hasSecondaryEffect) {
@@ -775,6 +782,9 @@ function buildDescription(description) {
     }
     if (description.isPowerSpot) {
         output += "Power Spot ";
+    }
+    if (description.isSteelySpirit) {
+        output += "Steely Spirit ";
     }
     if (description.isBattery) {
         output += "Battery ";

--- a/script_res/move_data.js
+++ b/script_res/move_data.js
@@ -3237,6 +3237,32 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         type: 'Steel',
         category: 'Special',
     },
+    'Mystical Fire': {
+        bp: 75,
+        type: 'Fire',
+        category: 'Special',
+        hasSecondaryEffect: true,
+    },
+    'Rock Wrecker': {
+        bp: 150,
+        type: 'Rock',
+        category: 'Physical',
+    },
+    'Blast Burn': {
+        bp: 150,
+        type: 'Fire',
+        category: 'Special',
+    },
+    'Hydro Cannon': {
+        bp: 150,
+        type: 'Water',
+        category: 'Special',
+    },
+    'Frenzy Plant': {
+        bp: 150,
+        type: 'Grass',
+        category: 'Special',
+    },
     'Max Strike': {
         type: 'Normal'
     },


### PR DESCRIPTION
Added Steely Spirit with a selector similar to how Helping Hand or Power Spot are handled now.

Added Mystical Fire, Frenzy Plant, Blast Burn, Hydro Cannon and Rock Wrecker.

Fixed bug that was preventing crit + max move from being selected at the same time.

All have been tested locally prior to PR.